### PR TITLE
Fix typo in Lists notebook

### DIFF
--- a/Lists.ipynb
+++ b/Lists.ipynb
@@ -278,7 +278,7 @@
     {
       "cell_type": "markdown",
       "source": [
-        "pop extension will show the last item in the list. In these methods we need to put open paranthesis at the end (). "
+        "pop extension will show the last item in the list. In these methods we need to put open parenthesis at the end (). "
       ],
       "metadata": {
         "id": "Ar9hMPj167jq"


### PR DESCRIPTION
## Summary
- fix spelling of "parenthesis" in Lists notebook

## Testing
- `jq . Lists.ipynb`

------
https://chatgpt.com/codex/tasks/task_e_685c647c958c832783b21af93cc4499b