### PR TITLE
Add countdown app CLI, persistence, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,89 @@
-# Freshstart
+# Freshstart Countdown App
+
+This repository contains a simple countdown planning utility with a command-line
+interface for creating plans, logging daily performance, and reviewing progress
+against goals.
+
+## Setup
+
+1. Create and activate a virtual environment (optional but recommended):
+
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+
+2. Install development dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+   If a `requirements.txt` file is not available, install `pytest` manually for
+   running the tests:
+
+   ```bash
+   pip install pytest
+   ```
+
+## Package Layout
+
+```
+countdown_app/
+├── cli.py          # Command-line entry point
+├── models.py       # Dataclasses and progress helpers
+├── storage.py      # JSON persistence helpers
+└── __init__.py
+```
+
+Daily plan data is stored under `data/plans.json` in JSON format.
+
+## Usage
+
+The CLI uses subcommands for creating plans, logging progress, and displaying a
+summary.
+
+Create a countdown plan with one or more goal metrics:
+
+```bash
+python -m countdown_app.cli create "Launch" 2023-10-01 30 \
+  --goal miles=100 --goal sessions=10
+```
+
+Log performance for a specific date (use multiple `--metric` flags for each
+metric you want to update):
+
+```bash
+python -m countdown_app.cli log "Launch" 2023-10-02 \
+  --metric miles=5 --metric sessions=1
+```
+
+Display the current status and progress breakdown:
+
+```bash
+python -m countdown_app.cli status "Launch"
+```
+
+## Progress Calculations
+
+Each plan tracks goal metrics (for example, total miles to run or number of
+study sessions). Daily log entries accumulate the values for each metric. The
+application sums all logged values per metric and compares them to the goal to
+compute a completion percentage, capped between 0 and 100 percent.
+
+The status command outputs:
+
+- Total progress accumulated for each metric.
+- Percentage completion toward the goals.
+- Days elapsed since the start and remaining days until the scheduled end.
+
+These metrics help you quickly understand how well you are tracking toward your
+countdown objectives.
+
+## Testing
+
+Run the unit test suite with:
+
+```bash
+pytest
+```

--- a/countdown_app/__init__.py
+++ b/countdown_app/__init__.py
@@ -1,0 +1,4 @@
+"""Countdown application package."""
+from .models import CountdownPlan, summarize_progress
+
+__all__ = ["CountdownPlan", "summarize_progress"]

--- a/countdown_app/cli.py
+++ b/countdown_app/cli.py
@@ -1,0 +1,118 @@
+"""Command-line interface for managing countdown plans."""
+from __future__ import annotations
+
+import argparse
+from datetime import date
+from typing import Dict
+
+from .models import CountdownPlan, summarize_progress
+from .storage import append_progress, load_plans, save_plans
+
+
+def _parse_metrics(pairs: list[str]) -> Dict[str, float]:
+    metrics: Dict[str, float] = {}
+    for pair in pairs:
+        if "=" not in pair:
+            raise argparse.ArgumentTypeError("Metrics must be in key=value format")
+        key, value = pair.split("=", 1)
+        try:
+            metrics[key] = float(value)
+        except ValueError as exc:
+            raise argparse.ArgumentTypeError(f"Invalid numeric value for '{key}': {value}") from exc
+    return metrics
+
+
+def _parse_date(value: str) -> str:
+    # Validate ISO date format without storing as date object (to keep argparse simple).
+    try:
+        date.fromisoformat(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("Dates must be in ISO format YYYY-MM-DD") from exc
+    return value
+
+
+def cmd_create(args: argparse.Namespace) -> None:
+    plans = load_plans()
+    if args.name in plans:
+        raise SystemExit(f"Plan '{args.name}' already exists")
+    plan = CountdownPlan(
+        name=args.name,
+        start_date=args.start_date,
+        duration_days=args.duration,
+        goal_metrics=args.goal,
+    )
+    plans[plan.name] = plan
+    save_plans(plans)
+    print(f"Created plan '{plan.name}' starting {plan.start_date.isoformat()} for {plan.duration_days} days")
+
+
+def cmd_log(args: argparse.Namespace) -> None:
+    plan = append_progress(args.name, args.date, args.metric)
+    print(f"Logged progress for '{plan.name}' on {args.date}")
+
+
+def cmd_status(args: argparse.Namespace) -> None:
+    plans = load_plans()
+    if args.name not in plans:
+        raise SystemExit(f"Plan '{args.name}' does not exist")
+    plan = plans[args.name]
+    summary = summarize_progress(plan)
+    print(f"Plan: {summary['name']}")
+    print(f"Start: {summary['start_date']} | End: {summary['end_date']}")
+    print(f"Duration: {summary['duration_days']} days")
+    print(f"Days elapsed: {summary['days_elapsed']} | Remaining: {summary['remaining_days']}")
+    print("Progress totals:")
+    for metric, value in summary["progress_totals"].items():
+        print(f"  - {metric}: {value:.2f}")
+    print("Progress percentages:")
+    for metric, value in summary["progress_percentages"].items():
+        print(f"  - {metric}: {value:.1f}%")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Countdown plan manager")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    create = subparsers.add_parser("create", help="Create a new countdown plan")
+    create.add_argument("name", help="Unique name of the plan")
+    create.add_argument("start_date", type=_parse_date, help="Start date (YYYY-MM-DD)")
+    create.add_argument("duration", type=int, help="Duration in days")
+    create.add_argument(
+        "--goal",
+        metavar="metric=value",
+        action="append",
+        default=[],
+        help="Goal metrics for the plan (can be used multiple times)",
+    )
+    create.set_defaults(func=cmd_create)
+
+    log = subparsers.add_parser("log", help="Log daily performance for a plan")
+    log.add_argument("name", help="Name of the plan")
+    log.add_argument("date", type=_parse_date, help="Date of the log entry (YYYY-MM-DD)")
+    log.add_argument(
+        "--metric",
+        metavar="metric=value",
+        action="append",
+        default=[],
+        help="Metric value for the day (can be used multiple times)",
+    )
+    log.set_defaults(func=cmd_log)
+
+    status = subparsers.add_parser("status", help="Display plan status")
+    status.add_argument("name", help="Name of the plan")
+    status.set_defaults(func=cmd_status)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    # Normalise optional arguments to dicts
+    args.goal = _parse_metrics(args.goal) if hasattr(args, "goal") else {}
+    args.metric = _parse_metrics(args.metric) if hasattr(args, "metric") else {}
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/countdown_app/models.py
+++ b/countdown_app/models.py
@@ -1,0 +1,112 @@
+"""Core data structures and helper functions for countdown plans."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date, datetime, timedelta
+from typing import Dict, Iterable, List, Mapping, Optional
+
+
+def _coerce_date(value: date | datetime | str) -> date:
+    """Convert a variety of date-like values into a :class:`datetime.date`."""
+    if isinstance(value, date) and not isinstance(value, datetime):
+        return value
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, str):
+        return datetime.fromisoformat(value).date()
+    raise TypeError(f"Unsupported date value: {value!r}")
+
+
+@dataclass
+class CountdownPlan:
+    """Represents a countdown plan with progress tracking."""
+
+    name: str
+    start_date: date
+    duration_days: int
+    goal_metrics: Dict[str, float]
+    progress_log: List["ProgressEntry"] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        self.start_date = _coerce_date(self.start_date)
+        processed: list[ProgressEntry] = []
+        for entry in self.progress_log:
+            if isinstance(entry, ProgressEntry):
+                processed.append(entry)
+            else:
+                processed.append(ProgressEntry.from_mapping(entry))
+        self.progress_log = processed
+
+    @property
+    def end_date(self) -> date:
+        """Return the date on which the plan is scheduled to end."""
+        return self.start_date + timedelta(days=self.duration_days)
+
+    def remaining_days(self, as_of: Optional[date | datetime] = None) -> int:
+        """Return the number of days remaining (never less than zero)."""
+        today = _coerce_date(as_of or date.today())
+        remaining = (self.end_date - today).days
+        return max(0, remaining)
+
+    def days_elapsed(self, as_of: Optional[date | datetime] = None) -> int:
+        """Return the number of days that have elapsed since the plan started."""
+        today = _coerce_date(as_of or date.today())
+        elapsed = (today - self.start_date).days
+        return max(0, elapsed)
+
+    def log_progress(self, entry_date: date | datetime | str, metrics: Mapping[str, float]) -> None:
+        """Record a daily progress entry for the plan."""
+        entry = ProgressEntry(date=_coerce_date(entry_date), metrics=dict(metrics))
+        self.progress_log.append(entry)
+
+    def aggregate_progress(self) -> Dict[str, float]:
+        """Aggregate the cumulative progress for each metric."""
+        totals: Dict[str, float] = {metric: 0.0 for metric in self.goal_metrics}
+        for entry in self.progress_log:
+            for key, value in entry.metrics.items():
+                totals[key] = totals.get(key, 0.0) + float(value)
+        return totals
+
+    def progress_percentages(self) -> Dict[str, float]:
+        """Return the percentage completion for each metric (0-100)."""
+        totals = self.aggregate_progress()
+        percentages: Dict[str, float] = {}
+        for metric, goal in self.goal_metrics.items():
+            if goal == 0:
+                percentages[metric] = 100.0 if totals.get(metric, 0.0) >= 0 else 0.0
+            else:
+                percentages[metric] = max(0.0, min(100.0, (totals.get(metric, 0.0) / goal) * 100))
+        return percentages
+
+
+@dataclass
+class ProgressEntry:
+    """Represents a daily progress update for a plan."""
+
+    date: date
+    metrics: Dict[str, float]
+
+    def __post_init__(self) -> None:
+        self.date = _coerce_date(self.date)
+        self.metrics = {key: float(value) for key, value in self.metrics.items()}
+
+    def to_dict(self) -> Dict[str, object]:
+        return {"date": self.date.isoformat(), "metrics": self.metrics}
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, object]) -> "ProgressEntry":
+        return cls(date=_coerce_date(data["date"]), metrics=dict(data["metrics"]))
+
+
+def summarize_progress(plan: CountdownPlan) -> Dict[str, object]:
+    """Return a dictionary summarising the current state of the plan."""
+    return {
+        "name": plan.name,
+        "start_date": plan.start_date.isoformat(),
+        "end_date": plan.end_date.isoformat(),
+        "duration_days": plan.duration_days,
+        "days_elapsed": plan.days_elapsed(),
+        "remaining_days": plan.remaining_days(),
+        "progress_totals": plan.aggregate_progress(),
+        "progress_percentages": plan.progress_percentages(),
+    }

--- a/countdown_app/storage.py
+++ b/countdown_app/storage.py
@@ -1,0 +1,76 @@
+"""Persistence helpers for countdown plans."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Iterable, Mapping
+
+from .models import CountdownPlan, ProgressEntry
+
+DATA_DIR = Path(__file__).resolve().parent.parent / "data"
+PLANS_PATH = DATA_DIR / "plans.json"
+
+
+def _ensure_data_dir(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def load_plans(path: Path = PLANS_PATH) -> Dict[str, CountdownPlan]:
+    """Load countdown plans from the given JSON file."""
+    if not path.exists():
+        return {}
+    with path.open("r", encoding="utf-8") as fh:
+        raw = json.load(fh)
+    plans: Dict[str, CountdownPlan] = {}
+    for plan_data in raw.get("plans", []):
+        plan = CountdownPlan(
+            name=plan_data["name"],
+            start_date=plan_data["start_date"],
+            duration_days=plan_data["duration_days"],
+            goal_metrics=dict(plan_data.get("goal_metrics", {})),
+            progress_log=[ProgressEntry.from_mapping(entry) for entry in plan_data.get("progress_log", [])],
+        )
+        plans[plan.name] = plan
+    return plans
+
+
+def save_plans(plans: Mapping[str, CountdownPlan], path: Path = PLANS_PATH) -> None:
+    """Persist countdown plans to disk."""
+    _ensure_data_dir(path)
+    serialised = {
+        "plans": [
+            {
+                "name": plan.name,
+                "start_date": plan.start_date.isoformat(),
+                "duration_days": plan.duration_days,
+                "goal_metrics": plan.goal_metrics,
+                "progress_log": [entry.to_dict() for entry in plan.progress_log],
+            }
+            for plan in plans.values()
+        ]
+    }
+    with path.open("w", encoding="utf-8") as fh:
+        json.dump(serialised, fh, indent=2)
+
+
+def upsert_plan(plan: CountdownPlan, path: Path = PLANS_PATH) -> None:
+    """Insert or update a plan in persistent storage."""
+    plans = load_plans(path)
+    plans[plan.name] = plan
+    save_plans(plans, path)
+
+
+def append_progress(
+    plan_name: str,
+    entry_date: str,
+    metrics: Mapping[str, float],
+    path: Path = PLANS_PATH,
+) -> CountdownPlan:
+    """Append a progress entry to the plan and persist the change."""
+    plans = load_plans(path)
+    if plan_name not in plans:
+        raise KeyError(f"Plan '{plan_name}' does not exist")
+    plan = plans[plan_name]
+    plan.log_progress(entry_date, metrics)
+    save_plans(plans, path)
+    return plan

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,40 @@
+from datetime import date
+
+import pytest
+
+from countdown_app.models import CountdownPlan, summarize_progress
+
+
+def create_plan():
+    return CountdownPlan(
+        name="Launch",
+        start_date=date(2023, 1, 1),
+        duration_days=10,
+        goal_metrics={"miles": 100.0, "sessions": 5},
+    )
+
+
+def test_remaining_days_and_elapsed():
+    plan = create_plan()
+    assert plan.remaining_days(date(2023, 1, 5)) == 6
+    assert plan.days_elapsed(date(2023, 1, 5)) == 4
+    assert plan.remaining_days(date(2023, 1, 15)) == 0
+
+
+def test_progress_percentages():
+    plan = create_plan()
+    plan.log_progress(date(2023, 1, 1), {"miles": 20, "sessions": 1})
+    plan.log_progress(date(2023, 1, 2), {"miles": 30})
+    plan.log_progress(date(2023, 1, 3), {"sessions": 2})
+    percentages = plan.progress_percentages()
+    assert pytest.approx(percentages["miles"], rel=1e-3) == 50.0
+    assert pytest.approx(percentages["sessions"], rel=1e-3) == 60.0
+
+
+def test_summarize_progress_structure():
+    plan = create_plan()
+    plan.log_progress(date(2023, 1, 1), {"miles": 25})
+    summary = summarize_progress(plan)
+    assert summary["name"] == "Launch"
+    assert summary["progress_totals"]["miles"] == 25
+    assert "remaining_days" in summary

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,44 @@
+from datetime import date
+
+import pytest
+
+from countdown_app.models import CountdownPlan
+from countdown_app import storage
+
+
+def sample_plan() -> CountdownPlan:
+    plan = CountdownPlan(
+        name="Build",
+        start_date=date(2023, 2, 1),
+        duration_days=5,
+        goal_metrics={"tasks": 10},
+    )
+    plan.log_progress(date(2023, 2, 1), {"tasks": 2})
+    return plan
+
+
+def test_save_and_load_round_trip(tmp_path):
+    path = tmp_path / "plans.json"
+    plan = sample_plan()
+    storage.save_plans({plan.name: plan}, path)
+    loaded = storage.load_plans(path)
+    assert plan.name in loaded
+    restored = loaded[plan.name]
+    assert restored.goal_metrics == plan.goal_metrics
+    assert restored.aggregate_progress()["tasks"] == 2
+
+
+def test_append_progress(tmp_path):
+    path = tmp_path / "plans.json"
+    plan = sample_plan()
+    storage.save_plans({plan.name: plan}, path)
+    updated = storage.append_progress(plan.name, "2023-02-02", {"tasks": 3}, path)
+    assert len(updated.progress_log) == 2
+    reloaded = storage.load_plans(path)
+    assert reloaded[plan.name].aggregate_progress()["tasks"] == 5
+
+
+def test_append_progress_missing_plan(tmp_path):
+    path = tmp_path / "plans.json"
+    with pytest.raises(KeyError):
+        storage.append_progress("missing", "2023-02-01", {"tasks": 1}, path)


### PR DESCRIPTION
## Summary
- add countdown plan data models and helpers for tracking progress
- implement JSON-backed storage and a command-line interface for managing plans
- cover the new functionality with unit tests and expanded documentation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e442c69c8c8327be6825f4a1728500